### PR TITLE
Fixed an issue where .ref1/.ref2 were in wrong place for /api/image/:id/:in angles

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -111,8 +111,8 @@ router.get('/image/:id/:in', (req, res) => {
       angle.find({_id: req.params.id }, { fields: " pts.ref1 pts.ref2 " }, (err, items) => {
         if(items.length > 0) {
           data["error"]   =   0;
-          data["ref1"]  =   items[0].pts[req.params.in.ref1];
-          data["ref2"]  =   items[0].pts[req.params.in.ref2];
+          data["ref1"]  =   items[0].pts[req.params.in].ref1;
+          data["ref2"]  =   items[0].pts[req.params.in].ref2;
           res.json(data);
         }
         else {


### PR DESCRIPTION
.ref1 and .ref2 properties were misplaced inside of the array brackets instead of outside for the angles portion of GET /api/image/:id/:in